### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,12 @@ What you need to do:
 
 //Thanks to Erica Sadun for her UIDevice+Hardware Addition (used for the mac address retrieval).
 
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=UIDeviceAddition.xcodeproj&amp;target=UIDeviceAddition&amp;repo_url=git%3A%2F%2Fgithub.com%2Fgekitz%2FUIDevice-with-UniqueIdentifier-for-iOS-5.git&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
+
 # License
 see license file.
 


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
